### PR TITLE
chore: Drop base-version

### DIFF
--- a/org.twinery.Twine.yaml
+++ b/org.twinery.Twine.yaml
@@ -1,6 +1,5 @@
 app-id: org.twinery.Twine
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
base version is inherited from the runtime version and has to be kept in sync anyway. Therefore dropping it, makes future updates easier and saver.