### PR TITLE
Upgrade/runtime-25.08, set Wayland to default, Twine 2.11.0 app update

### DIFF
--- a/org.twinery.Twine.metainfo.xml
+++ b/org.twinery.Twine.metainfo.xml
@@ -34,6 +34,18 @@
     <color type="primary" scheme_preference="dark">#0a5448</color>
   </branding>
   <releases>
+    <release version="2.11.0" date="2025-11-02">
+      <url type="details">https://twinery.org/reference/en/release-notes/2-11.html#2110</url>
+      <description>
+        <ul>
+          <li>Electron version has been updated</li>
+          <li>Passage tagging has undergone multiple interface refinements</li>
+          <li>Deselect All button has been added which deselects all passages</li>
+          <li>Find and replace function refined to avoid passage name conflict</li>
+          <li>Snowman story formats have been updated to versions 1.5.0 and 2.1.1</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.10.0" date="2024-11-24">
       <url type="details">https://twinery.org/reference/en/release-notes/2-10.html#2100</url>
       <description>

--- a/org.twinery.Twine.yaml
+++ b/org.twinery.Twine.yaml
@@ -51,8 +51,8 @@ modules:
         only-arches:
           - aarch64
         dest-filename: twine.zip
-        url: https://github.com/klembot/twinejs/releases/download/2.10.0/Twine-2.10.0-Linux-arm64.zip
-        sha256: 41b354520a814e7fc5182ae0252177d31e403f9dde492c85fa9eb8b3065d17e9
+        url: https://github.com/klembot/twinejs/releases/download/2.11.0/Twine-2.11.0-Linux-arm64.zip
+        sha256: 36b76f796ccc7621f0317f651c1584c175a39ff17c794503847e61b64397544c
         x-checker-data:
           type: json
           url: https://api.github.com/repos/klembot/twinejs/releases/latest
@@ -63,8 +63,8 @@ modules:
         only-arches:
           - x86_64
         dest-filename: twine.zip
-        url: https://github.com/klembot/twinejs/releases/download/2.10.0/Twine-2.10.0-Linux-x64.zip
-        sha256: 21423609477b46a2228ec55123cb0885c27d6b0be0e4d05ba37364f50d41a751
+        url: https://github.com/klembot/twinejs/releases/download/2.11.0/Twine-2.11.0-Linux-x64.zip
+        sha256: ed9ea9829de52ea334db5ca8fcb43c878f37f381ea4d7682b9157bb7182712e2
         x-checker-data:
           type: json
           url: https://api.github.com/repos/klembot/twinejs/releases/latest

--- a/org.twinery.Twine.yaml
+++ b/org.twinery.Twine.yaml
@@ -1,18 +1,18 @@
 app-id: org.twinery.Twine
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '25.08'
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: twine-wrapper
 copy-icon: true
 separate-locales: false
 finish-args:
-  # Required due to being a GUI application
-  - --socket=x11
-  # Required to make sure x11 performance is achived on all platforms
-  # At least that's what the legends tell. it might be worth experimenting
-  # with dropping this permission.
+  # Required due to being a GUI application, with X11 as a fallback
+  # if Wayland is unsupported
+  - --socket=wayland
+  - --socket=x11-fallback
+  # Supposed to make X11 more performant, if used.
   - --share=ipc
   # Required to download remote story formats.
   - --share=network
@@ -23,6 +23,8 @@ finish-args:
   - --filesystem=xdg-download
   # Allows to safe stories (Twine uses this directory by default)
   - --filesystem=xdg-documents/Twine:create
+  # Ensure proper mouse cursor scaling on HiDPI displays under Wayland
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/org.twinery.Twine.yaml
+++ b/org.twinery.Twine.yaml
@@ -11,7 +11,7 @@ finish-args:
   # Required due to being a GUI application, with X11 as a fallback
   # if Wayland is unsupported
   - --socket=wayland
-  - --socket=x11-fallback
+  - --socket=fallback-x11
   # Supposed to make X11 more performant, if used.
   - --share=ipc
   # Required to download remote story formats.


### PR DESCRIPTION
This one should work better.
Combining the automated 2.11.0 update pull which wouldn't render and gave error
`[2:1102/213731.741551:ERROR:ui/ozone/platform/wayland/host/wayland_connection.cc:202] Failed to connect to Wayland display: No such file or directory (2)`
`[2:1102/213731.741567:ERROR:ui/ozone/platform/wayland/ozone_platform_wayland.cc:282] Failed to initialize Wayland platform`
`[2:1102/213731.741607:ERROR:ui/aura/env.cc:257] The platform failed to initialize.  Exiting.`

Added patch notes and a link to the project's patch notes.
Updated Runtime 23.08 to 25.08.
Set Wayland to default with a fallback to X11.